### PR TITLE
Resolve the issue of quotation marks in the .env file that are causin…

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -29,8 +29,8 @@ ABUSE_SUPPORT_EMAIL=abuse@$DOMAIN
 SECURITY_SUPPORT_EMAIL=security@$DOMAIN
 
 MAS_CLIENT_ID="0000000000000000000SYNAPSE"
-MAS_EMAIL_FROM='"Matrix Authentication Service" <support@${DOMAIN}>'
-MAS_EMAIL_REPLY_TO='"Matrix Authentication Service" <support@${DOMAIN}>'
+MAS_EMAIL_FROM=Matrix Authentication Service <support@${DOMAIN}>
+MAS_EMAIL_REPLY_TO=Matrix Authentication Service <support@${DOMAIN}>
 
 # This should be the public IP of your $LIVEKIT_FQDN.
 # If livekit doesn't work, double-check this.


### PR DESCRIPTION
…g the DOMAIN substitution to malfunction (Ubuntu 24.04.1 LTS).