### PR TITLE
Easy fix on .env

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -29,8 +29,8 @@ ABUSE_SUPPORT_EMAIL=abuse@$DOMAIN
 SECURITY_SUPPORT_EMAIL=security@$DOMAIN
 
 MAS_CLIENT_ID="0000000000000000000SYNAPSE"
-MAS_EMAIL_FROM=Matrix Authentication Service <support@${DOMAIN}>
-MAS_EMAIL_REPLY_TO=Matrix Authentication Service <support@${DOMAIN}>
+MAS_EMAIL_FROM="Matrix Authentication Service <support@$DOMAIN>"
+MAS_EMAIL_REPLY_TO="Matrix Authentication Service <support@$DOMAIN>"
 
 # This should be the public IP of your $LIVEKIT_FQDN.
 # If livekit doesn't work, double-check this.


### PR DESCRIPTION
When running `./setup` with the letsencrypt option we got this error:

```
.env: line 32: syntax error near unexpected token `newline'
```

Seems like it was just some double quote escaping that are missing on the `.env-sample`. I fixed the file in local and re-run the `./setup`, everything went great.

So I just propose the change really fast for the others :)